### PR TITLE
Python 2.7 --> Python3.6 for dictionaries problem

### DIFF
--- a/intro-to-python/dictionaries.md
+++ b/intro-to-python/dictionaries.md
@@ -169,7 +169,7 @@ def get_value_from_dictionary(dict, key):
 ##### !challenge
 
 * type: code-snippet
-* language: python2.7
+* language: python3.6
 * id: e165737f-196a-4872-b674-4f70ccbb57e8
 * title: Dictionary Counter
 * points: 1
@@ -195,7 +195,6 @@ Example inputs and outputs:
 ##### !placeholder
 
 ```python
-
 def dict_counter(dict, key):
     pass
 
@@ -226,7 +225,6 @@ class TestDictCounter(unittest.TestCase):
         
         dict = dict_counter(dict, "cat")
         self.assertEqual(dict, {"dog":1, "tree":1, "star":4, "cat":2})
-
 
 ```
 ##### !end-tests


### PR DESCRIPTION
I noticed this problem was set to Python 2.7 instead of Python 3.6.

Also Learn wasn't running properly with it.  Tests were just not finishing, maybe this will fix it. 