### PR TITLE
refactor get_word_progress into two functions

### DIFF
--- a/intro-to-python/dictionaries.md
+++ b/intro-to-python/dictionaries.md
@@ -570,13 +570,13 @@ Now we're going to get back to our original goal, displaying each letter of the 
 * type: code-snippet
 * language: python3.6
 * id: 8b55c0e8-f7db-45e3-8fdc-ae6a70e0fb32
-* title: Get Word Progress
+* title: Generate Word Progress String
 * points: 1
 * topics: python, dictionaries
 
 ##### !question
 
-Write a helper function `get_word_progress` that takes two variables, a word and a dictionary where each letter in the word is a key and the values are `True` or `False`.  The function returns a string that represents the word, with spaces between each letter.  For each letter, if the value in the dictionary is `True`, the letter is displayed.  If the value in the dictionary is `False`, the letter is replaced with a `_` character.
+Write a helper function `generate_word_progress_string` that takes two variables, a word and a dictionary where each letter in the word is a key and the values are `True` or `False`.  The function returns a string that represents the word, with spaces between each letter.  For each letter, if the value in the dictionary is `True`, the letter is displayed.  If the value in the dictionary is `False`, the letter is replaced with a `_` character.
 
 Example inputs and outputs:
 
@@ -595,7 +595,7 @@ Example inputs and outputs:
 
 ```python
 
-def get_word_progress(word, word_dict):
+def generate_word_progress_string(word, word_dict):
     pass
 
 ```
@@ -606,18 +606,18 @@ def get_word_progress(word, word_dict):
 ```python
 
 import unittest
-from main import get_word_progress
+from main import generate_word_progress_string
 
 
 class TestGetWordProgress(unittest.TestCase):
     def test_mixed(self):
-        self.assertEqual(get_word_progress("pepper", {"p":True, "e": False, "r": False}), "p _ p p _ _")
+        self.assertEqual(generate_word_progress_string("pepper", {"p":True, "e": False, "r": False}), "p _ p p _ _")
 
     def test_all_false(self):
-        self.assertEqual(get_word_progress("tiger", {"e":False, "g": False, "i": False, "r": False, "t": False}), "_ _ _ _ _")
+        self.assertEqual(generate_word_progress_string("tiger", {"e":False, "g": False, "i": False, "r": False, "t": False}), "_ _ _ _ _")
     
     def test_all_true(self):
-        self.assertEqual(get_word_progress("swamp", {"a":True, "m": True, "p": True, "s": True, "w": True}), "s w a m p")
+        self.assertEqual(generate_word_progress_string("swamp", {"a":True, "m": True, "p": True, "s": True, "w": True}), "s w a m p")
 
 
 ```
@@ -630,10 +630,10 @@ Here is our implementation:
 
 ```python
 
-def get_word_progress(word, word_dict):
+def generate_word_progress_string(word, word_dict):
     output_string = ""
     elem_num = 0
-    
+
     for elem in word:
         if elem_num > 0:
             output_string += " "
@@ -642,9 +642,9 @@ def get_word_progress(word, word_dict):
             output_string += elem
         else:
             output_string += "_"
-            
+
         elem_num += 1
-            
+
     return output_string
     
 ```
@@ -655,13 +655,11 @@ def get_word_progress(word, word_dict):
 
 <!--END CHALLENGE-->
 
-Now that we have the helper function `get_word_progress` working, let's revisit our original goal.  Right now we're returning the display string, but we really want to display it.  Also, the name of the function `get_word_progress` implies that we're going to get some information about our user's progress toward guessing all of the letters.  Let's revisit this function and make some minor changes.
-
-First, let's switch to printing out the result instead of returning it:
+Now that we have the helper function `generate_word_progress_string` working, let's revisit our original goal.  Right now we're returning the display string, but we really want to display it. Let's switch to printing out the result instead of returning it. We'll rename our function to `print_word_progress_string`:
 
 ```python
 
-def get_word_progress(word, word_dict):
+def print_word_progress_string(word, word_dict):
     output_string = ""
     elem_num = 0
     
@@ -673,35 +671,25 @@ def get_word_progress(word, word_dict):
 
 ```
 
-Next, we want to return either `True` or `False`.  We are already looping through the word to build the output string, so now we need to add some logic to determine if every letter in the word has been guessed or not.  If all of them have been guessed, the function returns `True`.  If any of them haven't been guessed, the function returns `False`.
+### Getting Word Guessing Progress
+
+The helper function `print_word_progress_string` provides a visual display of the players progress towards guessing the word. We also need to write a function that returns `True` if all the letters have been guesses, and `False` otherwise. Let's name this function `get_word_progress`. 
+
+Similar to `print_word_progress_string`, to determine whether or not all the letters have been guessed, we need to loop through all the letters (keys) in the `word_dict` and check the corresponding values. If all of the letters have been guessed (all the values are `True`), the function returns `True`.  If any of the letters haven't been guessed (the value is `False`), the function returns `False`.  
 
 <br/>
 
 <details>
 
-<summary>Edit your <code>get_word_progress</code> helper function and when you are finished, compare your edits to ours.</summary>
+<summary>Implement the <code>get_word_progress</code> helper function and when you are finished, compare your function to ours.</summary>
 
 ```python
 
 def get_word_progress(word, word_dict):
-    output_string = ""
-    elem_num = 0
-    result = True
-
     for elem in word:
-        if elem_num > 0:
-            output_string += " "
-
-        if word_dict[elem]:
-            output_string += elem
-        else:
-            result = False
-            output_string += "_"
-
-        elem_num += 1
-
-    print(output_string)
-    return result
+        if not word_dict[elem]:
+            return False
+    return True
 
 ```
 
@@ -709,7 +697,7 @@ def get_word_progress(word, word_dict):
 
 ### Snowman Project
 
-We have all of the pieces we need to build the final version, and now it's time to bring all the pieces together into a fully functional Snowman game!  The last piece of the puzzle is to incorporate the `get_word_progress` helper function and end the game with a success message if the user guesses all of the letters in the word.  Use the following description of the final version as a guide and follow the link below to write and test your final version of Snowman!
+We have all of the pieces we need to build the final version, and now it's time to bring all the pieces together into a fully functional Snowman game!  The last piece of the puzzle is to incorporate the `print_word_progress_string` and `get_word_progress` helper functions and end the game with a success message if the user guesses all of the letters in the word.  Use the following description of the final version as a guide and follow the link below to write and test your final version of Snowman!
 
 Game Description:
 1. User starts the game from the command line

--- a/intro-to-python/dictionaries.md
+++ b/intro-to-python/dictionaries.md
@@ -559,8 +559,8 @@ Now we're going to get back to our original goal, displaying each letter of the 
 * Create an empty string
 * Loop over each letter in the word
 * Check if the letter has been guessed or not
-    * If the value of "guessed" is true add the letter to the string
-    * If the value of "guessed" is false add '_' to the string
+    * If the value of "guessed" is `True` add the letter to the string
+    * If the value of "guessed" is `False` add '_' to the string
 * Add 1 space between each letter/underscore
 
 <!--BEGIN CHALLENGE-->
@@ -576,7 +576,7 @@ Now we're going to get back to our original goal, displaying each letter of the 
 
 ##### !question
 
-Write a helper function `generate_word_progress_string` that takes two variables, a word and a dictionary where each letter in the word is a key and the values are `True` or `False`.  The function returns a string that represents the word, with spaces between each letter.  For each letter, if the value in the dictionary is `True`, the letter is displayed.  If the value in the dictionary is `False`, the letter is replaced with a `_` character.
+Write a helper function `generate_word_progress_string` that takes two parameters, a word and a dictionary where each letter in the word is a key and the values are `True` or `False`.  The function returns a string that represents the word, with spaces between each letter.  For each letter, if the value in the dictionary is `True`, the letter is displayed.  If the value in the dictionary is `False`, the letter is replaced with a `_` character.
 
 Example inputs and outputs:
 
@@ -609,7 +609,7 @@ import unittest
 from main import generate_word_progress_string
 
 
-class TestGetWordProgress(unittest.TestCase):
+class TestGetWordProgressString(unittest.TestCase):
     def test_mixed(self):
         self.assertEqual(generate_word_progress_string("pepper", {"p":True, "e": False, "r": False}), "p _ p p _ _")
 
@@ -673,15 +673,82 @@ def print_word_progress_string(word, word_dict):
 
 ### Getting Word Guessing Progress
 
-The helper function `print_word_progress_string` provides a visual display of the players progress towards guessing the word. We also need to write a function that returns `True` if all the letters have been guesses, and `False` otherwise. Let's name this function `get_word_progress`. 
+The helper function `print_word_progress_string` provides a visual display of the players progress towards guessing the word. We also need to write a function that indicates whether or not all the letters of the word have been guessed. We will name this function `get_word_progress`. The function `get_word_progress` should return `True` if all the letters have been guesses, and `False` otherwise.
 
-Similar to `print_word_progress_string`, to determine whether or not all the letters have been guessed, we need to loop through all the letters (keys) in the `word_dict` and check the corresponding values. If all of the letters have been guessed (all the values are `True`), the function returns `True`.  If any of the letters haven't been guessed (the value is `False`), the function returns `False`.  
 
-<br/>
+This function will need to:
 
-<details>
+* Loop over each letter (key) in the `word_dict`
+    * If `word_dict[letter]` is `False`, return `False`
+* Once the loop terminates without encountering a `False` value, return `True`
 
-<summary>Implement the <code>get_word_progress</code> helper function and when you are finished, compare your function to ours.</summary>
+
+<!--BEGIN CHALLENGE-->
+
+### !challenge
+
+* type: code-snippet
+* language: python3.6
+* id: df6395a3-bf75-4fa0-a8ab-b39e1d5f707b
+* title: Get Word Progress
+* points: 1
+* topics: python, dictionaries
+
+##### !question
+
+Write a helper function `get_word_progress(word, word_dict)` that takes two parameters, a word and a dictionary where each letter in the word is a key and the values are `True` or `False`.  The function returns `True` if every value in the dictionary is `True` and `False` if any of the values in the dictionary are `False`.
+
+Example inputs and outputs:
+
+|input|output|
+|--|--|
+|`word="pepper"` <br/> `word_dict={"p":True, "e": False, "r": False}`|`False`|
+|`word="tiger"` <br/> `word_dict={"e":False, "g": False, "i": False, "r": False, "t": False}`|`False`|
+|`word="swamp"` <br/> `word_dict={"a":True, "m": True, "p": True, "s": True, "w": True}`|`True`|
+
+<!--This can be regular **Markdown**-->
+
+##### !end-question
+
+##### !placeholder
+
+```python
+
+def get_word_progress(word, word_dict):
+    pass
+
+```
+
+##### !end-placeholder
+
+##### !tests
+```python
+
+import unittest
+from main import get_word_progress
+
+
+class TestGetWordProgress(unittest.TestCase):
+    def test_mixed_first_true(self):
+        self.assertEqual(get_word_progress("pepper", {"p":True, "e": False, "r": False}), False)
+
+    def test_mixed_last_true(self):
+        self.assertEqual(get_word_progress("pepper", {"p":False, "e": False, "r": True}), False)
+
+    def test_all_false(self):
+        self.assertEqual(get_word_progress("tiger", {"e":False, "g": False, "i": False, "r": False, "t": False}), False)
+    
+    def test_all_true(self):
+        self.assertEqual(get_word_progress("swamp", {"a":True, "m": True, "p": True, "s": True, "w": True}), True)
+
+
+```
+##### !end-tests
+
+<!--optional-->
+##### !explanation
+
+Here is our implementation:
 
 ```python
 
@@ -690,10 +757,14 @@ def get_word_progress(word, word_dict):
         if not word_dict[elem]:
             return False
     return True
-
+    
 ```
 
-</details>
+##### !end-explanation
+
+### !end-challenge
+
+<!--END CHALLENGE-->
 
 ### Snowman Project
 

--- a/intro-to-python/dictionaries.md
+++ b/intro-to-python/dictionaries.md
@@ -655,7 +655,7 @@ def generate_word_progress_string(word, word_dict):
 
 <!--END CHALLENGE-->
 
-Now that we have the helper function `generate_word_progress_string` working, let's revisit our original goal.  Right now we're returning the display string, but we really want to display it. Let's switch to printing out the result instead of returning it. We'll rename our function to `print_word_progress_string`:
+Now that we have the helper function `generate_word_progress_string` working, let's revisit our original goal.  Right now we're returning the progress string, but what we really want to do is display it. Let's switch to printing out the result instead of returning it. We'll rename our function to `print_word_progress_string`:
 
 ```python
 
@@ -680,7 +680,7 @@ This function will need to:
 
 * Loop over each letter (key) in the `word_dict`
     * If `word_dict[letter]` is `False`, return `False`
-* Once the loop terminates without encountering a `False` value, return `True`
+* If the loop terminates without encountering a `False` value, return `True`
 
 
 <!--BEGIN CHALLENGE-->
@@ -696,7 +696,7 @@ This function will need to:
 
 ##### !question
 
-Write a helper function `get_word_progress(word, word_dict)` that takes two parameters, a word and a dictionary where each letter in the word is a key and the values are `True` or `False`.  The function returns `True` if every value in the dictionary is `True` and `False` if any of the values in the dictionary are `False`.
+Write a helper function `get_word_progress(word, word_dict)` that takes two parameters, a word and a dictionary where each letter in the word is a key and the values are `True` or `False`.  The function returns `True` if every value in the dictionary is `True`. The function returns `False` if any of the values in the dictionary are `False`.
 
 Example inputs and outputs:
 

--- a/intro-to-python/resources/src/dictionaries/games_dictionary.md
+++ b/intro-to-python/resources/src/dictionaries/games_dictionary.md
@@ -90,18 +90,21 @@ def build_word_dict(word):
         word_dict[letter] = False
     return word_dict
     
-def get_word_progress(word, word_dict):
+def print_word_progress_string(word, word_dict):
     output_string = ""
-    result = True
     for elem in word:
         if word_dict[elem]:
             output_string += elem
         else:
-            result = False
             output_string += "_"
         output_string += " "
     print(output_string)
-    return result
+
+def get_word_progress(word, word_dict):
+    for elem in word:
+        if not word_dict[elem]:
+            return False
+    return True
 
 def get_letter_from_user(word_dict, list2):
     valid_input = False

--- a/intro-to-python/snowman.checkpoint.md
+++ b/intro-to-python/snowman.checkpoint.md
@@ -50,9 +50,11 @@ When adding your code, you only need to modify the `snowman(snowman_word)` funct
 You should make use of the following functions from the previous lessons (already created for you):
 
 - `print_snowman_graphic(num_wrong_guesses)` - This function prints out the appropriate snowman image depending on the number of wrong guesses the player has made.
-- `build_word_dict(snowman_word)` - This function takes snowman_word as input and returns a dictionary with a key-value pair for each letter in snowman_word, where the key is the letter and the value is `False`.
-- `get_letter_from_user(snowman_word_dict, wrong_guesses_list)` - This function takes the snowman_word_dict and the list of characters that have been guessed incorrectly (wrong_guesses_list) as input. It repeatedly asks the user to enter a single character until a valid character is provided. Once a valid character is entered, it is returned.
-- `get_word_progress(snowman_word, snowman_word_dict)` - This function takes the snowman_word and snowman_word_dict as input. It prints an output string that shows the correct letter guess placements as well as the placements for the letters yet to be guessed. It returns True if all the letters of the word have been guessed, and False otherwise.
+- `build_word_dict(snowman_word)` - This function takes `snowman_word` as input and returns a dictionary with a key-value pair for each letter in `snowman_word`, where the key is the letter and the value is `False`.
+- `get_letter_from_user(snowman_word_dict, wrong_guesses_list)` - This function takes the `snowman_word_dict` and the list of characters that have been guessed incorrectly (`wrong_guesses_list`) as input. It repeatedly asks the user to enter a single character until a valid character is provided. Once a valid character is entered, it is returned.
+- `print_word_progress_string(snowman_word, snowman_word_dict)` - This function takes the `snowman_word` and `snowman_word_dict` as input. It prints an output string that shows the correct letter guess placements as well as the placements for the letters yet to be guessed. 
+- `get_word_progress(snowman_word, snowman_word_dict)` - This function takes the `snowman_word` and `snowman_word_dict` as input.
+It returns `True` if all the letters of the word have been guessed, and `False` otherwise.
 
 
 When you finish place a link to your repl here.


### PR DESCRIPTION
This PR is to refactor get_word_progress  into two functions: `print_word_progress_string` and `get_word_progress`. 

When reviewing the snowman project I noticed that `get_word_progress` had two jobs -- one to print the string showing the progress on the guessing the word, the other to return `True` or `False` to indicate whether the word had been guessed. To follow the single responsibility principle and to make the function a little easier to understand, I broke this up into two functions.

These changes affected dictionaries lesson as well as the snowman project.

A link to a fork of the snowman project with this changes is here: https://replit.com/@BeccaElenzil/snowmanproject-2#game.py

This snowman fork also has changes to the test to handle StopIterration exceptions. These changes are detailed [here](https://app.asana.com/0/1201700438643002/1201886606520292/f)

If these changes are approved, we will need to make the changes to the adacore version of the replit project.

To Review:
- Preview in Learn
- Test the new code challenge

