### PR TITLE
Change plain spaces to non-breakable

### DIFF
--- a/intro-to-python/loops.md
+++ b/intro-to-python/loops.md
@@ -198,7 +198,7 @@ Example inputs and outputs:
 |input|output|
 |--|--|
 | `word = "snow"`|`"1 snow 2 snow 3 snow 4 snow 5 snow 6 snow 7 snow 8 snow 9 snow 10 snow "`|
-| `word = ""`|<code>"1&nbsp;&nbsp;2&nbsp;&nbsp;3&nbsp;&nbsp;4&nbsp;&nbsp;5&nbsp;&nbsp;6&nbsp;&nbsp;7&nbsp;&nbsp;8&nbsp;&nbsp;9&nbsp;&nbsp;10  "</code>|
+| `word = ""`|<code>"1&nbsp;&nbsp;2&nbsp;&nbsp;3&nbsp;&nbsp;4&nbsp;&nbsp;5&nbsp;&nbsp;6&nbsp;&nbsp;7&nbsp;&nbsp;8&nbsp;&nbsp;9&nbsp;&nbsp;10&nbsp;&nbsp;"</code>|
 | `word = "123"`|`"1 123 2 123 3 123 4 123 5 123 6 123 7 123 8 123 9 123 10 123 "`|
 
 ##### !end-question


### PR DESCRIPTION
Learn collapses multiple spaces (even in single code quotes) into one.
Since two spaces are needed here, we need to use nbsp entities to preserve them.

Currently in preview at: https://learn-2.galvanize.com/cohorts/2577/blocks/452/content_files/intro-to-python/loops.md#challenge_1818554

It's the second case (`word = ""`) which was showing only a single trailing space in the browser, when there were 2 spaces in the markdown (there should be two visible spaces after the 10).