### PR TITLE
Add new tile for Generative AI readings to precourse

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -101,6 +101,16 @@ Standards:
         Type: Resource
         UID: 8dcfa218-e7a1-499c-b30e-dab52ba8474b
         Path: /intro-to-python/resources/src/conditionals/games_conditional.md
+  - Title: Generative AI Overview
+    Description: Prework for in-class discussion on Generative AI & Large Learning Models
+    UID: 1eafe9d0-74fe-11ee-b962-0242ac120002
+    SuccessCriteria:
+      - success criteria
+    ContentFiles:
+      -
+        Type: Lesson
+        UID: 2db78e42-74fe-11ee-b962-0242ac120002
+        Path: /generative-ai-overview/generative-ai-prework.md
   - Title: Social Justice
     Description: Prework for the Social Justice Training
     UID: daffd069-1de3-43dd-9f15-37e66ddbf673
@@ -111,3 +121,4 @@ Standards:
         Type: Lesson
         UID: be54361c-2647-45bc-87a4-2b3673e496ea
         Path: /ada-equity-work/ada-social-justice-work.md
+

--- a/generative-ai-overview/generative-ai-prework.md
+++ b/generative-ai-overview/generative-ai-prework.md
@@ -13,6 +13,8 @@ However you choose to move through the materials, as you read through these reso
     * What kinds of impacts can that have when the responses are used to make decisions?
 3. What kinds of tasks are LLMs good at performing? What kinds of tasks do they struggle with? 
 4. What are a few considerations for using AI tools responsibly?
+5. What are some technical or physical limitations of LLMs?
+    * What are they able to process? What equipment or infrastructure does it take to keep an LLM running?
 
 ## Required Readings
 What are LLMs?

--- a/generative-ai-overview/generative-ai-prework.md
+++ b/generative-ai-overview/generative-ai-prework.md
@@ -1,0 +1,33 @@
+# Generative AI Prework
+
+The goal of the Generative AI pre-readings is to start Adies off with a common base of information around Large Language Models (LLMs) and the Generative AIs they power, as well as to prepare you for an in-class activity where we will discuss our takeaways and understanding of these readings.
+
+We will be introducing topics around Generative AI and showcasing some tools and techniques for working with them throughout the coursework, so we want to create a shared understanding of generally what an LLM is and how it operates. We acknowledge that students may have different levels of experience and interest with these topics before starting at Ada. Some folks may find it helpful to skim through the materials while others may want to do a couple close readings. 
+
+## Questions for Reflection
+
+However you choose to move through the materials, as you read through these resources, try to reflect on the following questions for our in-person discussion:
+1. Given a text prompt, how do LLMs like chatGPT try to create a response? 
+    * How does this differ from how people create responses when asked a question?
+2. How does the data a LLM was trained on affect the responses that they create? 
+    * What kinds of impacts can that have when the responses are used to make decisions?
+3. What kinds of tasks are LLMs good at performing? What kinds of tasks do they struggle with? 
+4. What are a few considerations for using AI tools responsibly?
+
+## Required Readings
+What are LLMs?
+* [Introduction to Large Language Models](https://developers.google.com/machine-learning/resources/intro-llms) - From Google's Machine Learning resources
+
+How does bias impact LLMs?
+* *Content Warning: there are no graphic depictions, but there are examples discussed of harmful sexist and racist content created by generative AIs* [Exploration of bias in ChatGPT and other AI models](https://www.insider.com/chatgpt-is-like-many-other-ai-models-rife-with-bias-2023-1) - from Insider.com
+
+What are some areas of strength and weakness of LLMs?
+* [Pitfalls of LLMs](https://learnprompting.org/docs/basics/pitfalls) - From learnprompting.org
+* [5 Practical Business Use Cases for Large Language Models](https://opendatascience.com/5-practical-business-use-cases-for-large-language-models/) -  From opendatascience.com
+
+## Further Readings
+The following resources are not required reading, but are provided for those who'd like to dive a little deeper into some of the topics above.
+
+* [Recognizing the kinds of biases in Generative AIs](https://www.forbes.com/sites/forbestechcouncil/2023/09/06/navigating-the-biases-in-llm-generative-ai-a-guide-to-responsible-implementation) - From Forbes.com
+* [Chatbot Hallucinations Are Poisoning Web Search](https://www.wired.com/story/fast-forward-chatbot-hallucinations-are-poisoning-web-search/) - From Wired.com
+* [What Happens When a Prompt Doesn't Work?](https://learnprompting.org/docs/basics/prompt_engineering#what-happens-when-a-prompt-doesnt-work) - From learnprompting.org


### PR DESCRIPTION
Adds a new tile to the precourse to inform students that there will be an in class discussion, share questions for reflection that will be used in the in-class activity, and link to articles that give high level information about LLMs and Generative AI.

This PR addresses this ticket: https://app.asana.com/0/1201700438643002/1205762659804145/f
The asana ticket also covers creating [a shareable doc for the in-class activity](https://docs.google.com/document/d/1F6MAomC65s9oAzCHg3yh57yrYHoCIo88jOoeCfI6qHk/edit).

 